### PR TITLE
지원하는 브라우저 정보 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         이 사이트를 정상적으로 사용하시려면 비동기 속성을 지원하는 브라우저가 필요합니다.<br>
         <a href="https://caniuse.com/#search=async" target="_blank">이 곳</a>에서 지원 가능한 브라우저를 확인하세요.
       </p>
-      <p>2017년 12월까지 73.32%의 브라우저가 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Statements/async_function" target="_blank">이 기능</a>을 지원하고 있습니다.</p>
+      <p>2019년 11월까지 91.76%의 브라우저가 <a href="https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Statements/async_function" target="_blank">이 기능</a>을 지원하고 있습니다.</p>
     </div>
   </div>
 </body>


### PR DESCRIPTION
caniuse.com을 참고한 결과 2019년 11월까지 91.76퍼센트의 브라우저가 async function을 지원한다고 합니다. 이에 맞춰 정보를 수정하였습니다.
